### PR TITLE
Fix copying file paths to clipboard on windows

### DIFF
--- a/copyStuff.lua
+++ b/copyStuff.lua
@@ -47,7 +47,7 @@ end
 
 local function set_clipboard(text)
     if platform == WINDOWS then
-        mp.commandv("run", "powershell", "set-clipboard", text)
+        mp.commandv("run", "powershell", "set-clipboard", table.concat({'"', text, '"'}))
         return true
     elseif (platform == UNIX and clipboard_cmd) then
         local pipe = io.popen(clipboard_cmd, "w")


### PR DESCRIPTION
This pull request fixes copying complex file paths to the clipboard on windows systems.

Originally if the file path contains special characters (e.g. a dash), powershell will try to be smart and interpret it, in the case of a dash as an option, and fail the operation if that does not exist:
```
Set-Clipboard : A positional parameter cannot be found that accepts argument '-'.------------------]
At line:1 char:1
+ set-clipboard 20230329-200626 - ELJÖTT A NAGY NAP! - !nyernék !samsun ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-Clipboard], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.SetClipboardCommand
```

This might also be a security vulnerability, if it is possible to name a file in a way so that powershell interprets part of it as a separate command.

The PR fixes this by enclosing the copied text in quotes.
Since on windows file paths cannot contain quote marks, the theoretical security vulnerbaility should also be solved.